### PR TITLE
Fix invalid JSON syntax in README Quick Start example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,12 @@ import { parseAndRender } from 'jempl';
 const template = {
   name: "${user.name}",
   greeting: "Hello ${user.name}!",
-  $if user.age >= 18:
+  "$if user.age >= 18": {
     status: "adult"
-  $else:
+  },
+  "$else": {
     status: "minor"
+  }
 };
 
 const data = {


### PR DESCRIPTION
## Summary
- Fixed invalid JSON syntax in the Quick Start example that would cause syntax errors
- Converted template object to proper JavaScript object literal format

## Changes
- Quote conditional keys: `"$if user.age >= 18"` and `"$else"`
- Use proper object syntax with braces and commas
- Ensure the example code is valid JavaScript that can actually run

## Benefits
- README example now shows correct, runnable code
- Prevents confusion for new users trying the Quick Start
- Maintains consistency with valid JSON/JavaScript syntax