### PR TITLE
Add semantic JSON conditions for $when

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,52 @@ cases:
           resource: "articles"
 ```
 
+#### Semantic JSON Conditions
+
+`$when` also accepts a structured JSON condition. This is useful when a UI or
+build step wants to store conditions without preserving an expression string.
+The JSON form is parsed into the same condition AST as string expressions, so it
+uses the same runtime evaluation logic.
+
+```yaml
+template:
+  route:
+    $when:
+      all:
+        - gte:
+            - var: variables.trust
+            - 70
+        - var: variables.metGuide
+    target: guideRoute
+
+cases:
+  - data:
+      variables:
+        trust: 80
+        metGuide: true
+    output:
+      route:
+        target: guideRoute
+```
+
+Supported JSON condition operators:
+
+- `{ var: "path.to.value" }` - Read a value from template data
+- `{ literal: value }` - Use an object or array literal explicitly
+- `{ all: [condition, ...] }` - Logical AND
+- `{ any: [condition, ...] }` - Logical OR
+- `{ not: condition }` - Logical NOT
+- `{ eq: [left, right] }`, `{ neq: [left, right] }`
+- `{ gt: [left, right] }`, `{ gte: [left, right] }`
+- `{ lt: [left, right] }`, `{ lte: [left, right] }`
+- `{ in: [needle, haystack] }`
+- `{ add: [left, right] }`, `{ sub: [left, right] }`
+- `{ call: "functionName", args: [arg, ...] }`
+
+Primitive JSON values are treated as literals. Strings are literal strings in
+the JSON form, so use `{ var: "name" }` when you want to read from template
+data.
+
 #### Combining $when with $if
 
 You can use `$when` and `$if` together - `$when` is evaluated first:

--- a/README.md
+++ b/README.md
@@ -427,6 +427,54 @@ cases:
         target: guideRoute
 ```
 
+More examples:
+
+```yaml
+# Match one of several roles
+$when:
+  any:
+    - eq:
+        - var: user.role
+        - "admin"
+    - eq:
+        - var: user.role
+        - "owner"
+```
+
+```yaml
+# Exclude disabled records
+$when:
+  not:
+    var: user.disabled
+```
+
+```yaml
+# Check membership against an explicit array literal
+$when:
+  in:
+    - var: user.role
+    - literal: ["admin", "moderator"]
+```
+
+```yaml
+# Compare a calculated value
+$when:
+  gte:
+    - add:
+        - var: score
+        - var: bonus
+    - 100
+```
+
+```yaml
+# Call a custom function
+$when:
+  call: hasFeature
+  args:
+    - var: user
+    - "beta-dashboard"
+```
+
 Supported JSON condition operators:
 
 - `{ var: "path.to.value" }` - Read a value from template data

--- a/README.md
+++ b/README.md
@@ -493,6 +493,10 @@ Primitive JSON values are treated as literals. Strings are literal strings in
 the JSON form, so use `{ var: "name" }` when you want to read from template
 data.
 
+Each semantic JSON condition object must contain exactly one condition operator.
+Use `all` or `any` to combine multiple conditions. For function calls, `args` is
+metadata for `call`, not a separate condition operator.
+
 #### Combining $when with $if
 
 You can use `$when` and `$if` together - `$when` is evaluated first:

--- a/docs/AST.md
+++ b/docs/AST.md
@@ -117,6 +117,8 @@ id: string | null # For multiple conditionals like $if#1
 **Note on $if vs $when:**
 - `$if`: Merges the body content into the parent object when condition is true
 - `$when`: Controls whether the entire object exists (stored as `whenCondition` on Object nodes)
+- `$when` accepts either a string expression or semantic JSON condition; both
+  parse into the same internal `whenCondition` node shape
 
 **Functions and arithmetic in conditionals:**
 - Conditions can contain function calls: `$if isEven(num):`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jempl",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A JSON templating engine with conditionals, loops, and custom functions",
   "main": "src/index.js",
   "types": "types/index.d.ts",

--- a/spec/parse/when.spec.yaml
+++ b/spec/parse/when.spec.yaml
@@ -76,6 +76,69 @@ out:
         type: 0
         value: "allowed"
 ---
+case: when with semantic JSON all condition
+in:
+  - $when:
+      all:
+        - gte:
+            - var: age
+            - 18
+        - var: hasPermission
+    action: "allowed"
+out:
+  type: 8
+  fast: false
+  whenCondition:
+    type: 4
+    op: 6
+    left:
+      type: 4
+      op: 4
+      left:
+        type: 1
+        path: "age"
+      right:
+        type: 0
+        value: 18
+    right:
+      type: 1
+      path: "hasPermission"
+  properties:
+    - key: action
+      value:
+        type: 0
+        value: "allowed"
+---
+case: when with semantic JSON function condition
+in:
+  - $when:
+      gt:
+        - call: getCount
+          args:
+            - var: items
+        - 2
+    status: "enough"
+out:
+  type: 8
+  fast: false
+  whenCondition:
+    type: 4
+    op: 2
+    left:
+      type: 3
+      name: "getCount"
+      args:
+        - type: 1
+          path: "items"
+    right:
+      type: 0
+      value: 2
+  properties:
+    - key: status
+      value:
+        type: 0
+        value: "enough"
+---
 case: when with logical OR
 in:
   - $when: isAdmin || isOwner

--- a/spec/parse/whenErrors.spec.yaml
+++ b/spec/parse/whenErrors.spec.yaml
@@ -43,6 +43,37 @@ in:
   - age: 20
 throws: "Parse Error: Condition JSON at '$when' must contain exactly one operator"
 ---
+case: semantic JSON when with operator and extra key
+in:
+  - "$when":
+      gt:
+        - var: age
+        - 18
+      label: "adult"
+    value: "test"
+  - age: 20
+throws: "Parse Error: Unexpected key 'label' in condition JSON at '$when'"
+---
+case: semantic JSON when with args without call
+in:
+  - "$when":
+      args:
+        - var: age
+    value: "test"
+  - age: 20
+throws: "Parse Error: Unknown condition JSON operator 'args' at '$when'"
+---
+case: semantic JSON when with call and another operator
+in:
+  - "$when":
+      call: isEven
+      gt:
+        - var: age
+        - 18
+    value: "test"
+  - age: 20
+throws: "Parse Error: Condition JSON at '$when' must contain exactly one operator"
+---
 case: semantic JSON when with empty all
 in:
   - "$when":

--- a/spec/parse/whenErrors.spec.yaml
+++ b/spec/parse/whenErrors.spec.yaml
@@ -20,6 +20,71 @@ in:
   - {}
 throws: "Parse Error: Empty condition expression after '$when'"
 ---
+case: semantic JSON when with unknown operator
+in:
+  - "$when":
+      unknown:
+        - var: age
+        - 18
+    value: "test"
+  - age: 20
+throws: "Parse Error: Unknown condition JSON operator 'unknown' at '$when'"
+---
+case: semantic JSON when with multiple operators
+in:
+  - "$when":
+      gt:
+        - var: age
+        - 18
+      lt:
+        - var: age
+        - 65
+    value: "test"
+  - age: 20
+throws: "Parse Error: Condition JSON at '$when' must contain exactly one operator"
+---
+case: semantic JSON when with empty all
+in:
+  - "$when":
+      all: []
+    value: "test"
+  - {}
+throws: "Parse Error: Condition JSON operator 'all' at '$when.all' requires at least 1 condition"
+---
+case: semantic JSON when with invalid comparison operand count
+in:
+  - "$when":
+      gte:
+        - var: age
+    value: "test"
+  - age: 20
+throws: "Parse Error: Condition JSON operator 'gte' at '$when.gte' requires exactly 2 operands"
+---
+case: semantic JSON when with empty variable path
+in:
+  - "$when":
+      var: ""
+    value: "test"
+  - {}
+throws: "Parse Error: Condition JSON var at '$when' requires a non-empty path"
+---
+case: semantic JSON when with invalid function args
+in:
+  - "$when":
+      call: isEven
+      args:
+        value: 2
+    value: "test"
+  - {}
+throws: "Parse Error: Condition JSON call 'isEven' at '$when' requires args to be an array"
+---
+case: semantic JSON when with direct array
+in:
+  - "$when": []
+    value: "test"
+  - {}
+throws: "Parse Error: Condition JSON array at '$when' must be wrapped in an operator or { literal: [...] }"
+---
 case: when with invalid operator (parser doesn't validate)
 in:
   - "$when": "age === 18"

--- a/spec/parseAndRender/partials.spec.yaml
+++ b/spec/parseAndRender/partials.spec.yaml
@@ -145,6 +145,36 @@ out:
       path: "/dashboard"
       active: false
 ---
+case: partial with semantic JSON $when in array
+in:
+  - menu:
+      - $when:
+          all:
+            - var: isLoggedIn
+            - gte:
+                - var: trust
+                - 70
+        $partial: "menuItem"
+        label: "Guide Route"
+        path: "/guide"
+      - $when:
+          lt:
+            - var: trust
+            - 70
+        $partial: "menuItem"
+        label: "Neutral Route"
+        path: "/neutral"
+  - isLoggedIn: true
+    trust: 72
+  - partials:
+      menuItem:
+        label: "${label}"
+        path: "${path}"
+out:
+  menu:
+    - label: "Guide Route"
+      path: "/guide"
+---
 case: partial with escaped dollar properties
 in:
   - $partial: "pricing"

--- a/spec/parseAndRender/when.spec.yaml
+++ b/spec/parseAndRender/when.spec.yaml
@@ -42,6 +42,98 @@ out:
     - status: "adult"
       canVote: true
 ---
+case: when with semantic JSON all condition
+in:
+  - access:
+      $when:
+        all:
+          - gte:
+              - var: user.trust
+              - 70
+          - var: user.metGuide
+      route: "guide"
+  - user:
+      trust: 72
+      metGuide: true
+  - functions: {}
+out:
+  access:
+    route: "guide"
+---
+case: when with semantic JSON all condition false
+in:
+  - access:
+      $when:
+        all:
+          - gte:
+              - var: user.trust
+              - 70
+          - var: user.metGuide
+      route: "guide"
+  - user:
+      trust: 72
+      metGuide: false
+  - functions: {}
+out: {}
+---
+case: when with semantic JSON any and not conditions
+in:
+  - menu:
+      - $when:
+          any:
+            - eq:
+                - var: role
+                - "admin"
+            - eq:
+                - var: role
+                - "owner"
+        label: "Admin"
+      - $when:
+          not:
+            var: disabled
+        label: "Enabled"
+  - role: "member"
+    disabled: false
+  - functions: {}
+out:
+  menu:
+    - label: "Enabled"
+---
+case: when with semantic JSON literal array membership
+in:
+  - menu:
+      - $when:
+          in:
+            - var: role
+            - literal: ["admin", "owner"]
+        label: "Privileged"
+      - $when:
+          in:
+            - var: role
+            - literal: ["guest"]
+        label: "Guest"
+  - role: "owner"
+  - functions: {}
+out:
+  menu:
+    - label: "Privileged"
+---
+case: when with semantic JSON function and arithmetic conditions
+in:
+  - status:
+      $when:
+        gte:
+          - add:
+              - call: getCount
+              - var: bonus
+          - 5
+      value: "qualified"
+  - bonus: 2
+  - functions: {}
+out:
+  status:
+    value: "qualified"
+---
 case: when in array filtering
 in:
   - products:

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,12 @@
 import render from "./render.js";
 import parse from "./parse/index.js";
 import parseAndRender from "./parseAndRender.js";
+import { parseConditionExpression, parseConditionJson } from "./parse/utils.js";
 
-export { render, parseAndRender, parse };
+export {
+  render,
+  parseAndRender,
+  parse,
+  parseConditionExpression,
+  parseConditionJson,
+};

--- a/src/parse/utils.js
+++ b/src/parse/utils.js
@@ -6,6 +6,22 @@ import {
   JemplParseError,
 } from "../errors.js";
 
+const isPlainObject = (value) =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+const getOwnKeys = (value) => Object.keys(value);
+
+const formatConditionJsonPath = (path) => path.join(".");
+
+const assertOnlyKeys = (value, allowedKeys, path) => {
+  const extraKeys = getOwnKeys(value).filter((key) => !allowedKeys.has(key));
+  if (extraKeys.length > 0) {
+    throw new JemplParseError(
+      `Unexpected key '${extraKeys[0]}' in condition JSON at '${formatConditionJsonPath(path)}'`,
+    );
+  }
+};
+
 /**
  * Parses any value (string, number, boolean, null, object, array)
  * @param {any} value - The value to parse
@@ -247,21 +263,7 @@ export const parseObject = (obj, functions) => {
 
     // Handle $when condition if present
     if ($when !== undefined) {
-      // Parse the when condition
-      let whenCondition;
-      if (typeof $when === "string") {
-        if ($when.trim() === "") {
-          throw new JemplParseError("Empty condition expression after '$when'");
-        }
-        whenCondition = parseConditionExpression($when, functions);
-      } else {
-        // Boolean or other literal value
-        whenCondition = {
-          type: NodeType.LITERAL,
-          value: $when,
-        };
-      }
-      result.whenCondition = whenCondition;
+      result.whenCondition = parseWhenCondition($when, functions);
     }
 
     return result;
@@ -279,13 +281,7 @@ export const parseObject = (obj, functions) => {
       if (value === undefined || value === null) {
         throw new JemplParseError("Missing condition expression after '$when'");
       }
-      // Convert non-string values to string for parsing
-      const conditionStr =
-        typeof value === "string" ? value : JSON.stringify(value);
-      if (conditionStr.trim() === "") {
-        throw new JemplParseError("Empty condition expression after '$when'");
-      }
-      whenCondition = parseConditionExpression(conditionStr, functions);
+      whenCondition = parseWhenCondition(value, functions);
       hasDynamicContent = true;
     } else if (key.startsWith("$when#") || key.startsWith("$when ")) {
       throw new JemplParseError(
@@ -492,6 +488,280 @@ export const parseConditional = (entries, startIndex, functions = {}) => {
       id: conditionId,
     },
     nextIndex: currentIndex,
+  };
+};
+
+const JSON_BINARY_OPERATORS = {
+  eq: BinaryOp.EQ,
+  neq: BinaryOp.NEQ,
+  gt: BinaryOp.GT,
+  gte: BinaryOp.GTE,
+  lt: BinaryOp.LT,
+  lte: BinaryOp.LTE,
+  in: BinaryOp.IN,
+  add: BinaryOp.ADD,
+  sub: BinaryOp.SUBTRACT,
+};
+
+const JSON_LOGICAL_OPERATORS = {
+  all: BinaryOp.AND,
+  any: BinaryOp.OR,
+};
+
+const JSON_CONDITION_OPERATORS = new Set([
+  "var",
+  "literal",
+  "call",
+  "not",
+  ...Object.keys(JSON_BINARY_OPERATORS),
+  ...Object.keys(JSON_LOGICAL_OPERATORS),
+]);
+
+const parseConditionJsonOperandList = (operands, operator, path) => {
+  if (!Array.isArray(operands)) {
+    throw new JemplParseError(
+      `Condition JSON operator '${operator}' at '${formatConditionJsonPath(path)}' requires an array`,
+    );
+  }
+
+  if (operands.length !== 2) {
+    throw new JemplParseError(
+      `Condition JSON operator '${operator}' at '${formatConditionJsonPath(path)}' requires exactly 2 operands`,
+    );
+  }
+
+  return operands;
+};
+
+const parseConditionJsonLogical = (
+  conditions,
+  operator,
+  binaryOp,
+  functions,
+  path,
+) => {
+  if (!Array.isArray(conditions)) {
+    throw new JemplParseError(
+      `Condition JSON operator '${operator}' at '${formatConditionJsonPath(path)}' requires an array`,
+    );
+  }
+
+  if (conditions.length === 0) {
+    throw new JemplParseError(
+      `Condition JSON operator '${operator}' at '${formatConditionJsonPath(path)}' requires at least 1 condition`,
+    );
+  }
+
+  const parsedConditions = conditions.map((condition, index) =>
+    parseConditionJson(condition, functions, [...path, index]),
+  );
+
+  return parsedConditions.reduce((left, right) => ({
+    type: NodeType.BINARY,
+    op: binaryOp,
+    left,
+    right,
+  }));
+};
+
+const parseConditionJsonFunction = (condition, functions, path) => {
+  let name;
+  let rawArgs;
+
+  if (typeof condition.call === "string") {
+    name = condition.call;
+    rawArgs = condition.args ?? [];
+    assertOnlyKeys(condition, new Set(["call", "args"]), path);
+  } else if (isPlainObject(condition.call)) {
+    name = condition.call.name;
+    rawArgs = condition.call.args ?? [];
+    assertOnlyKeys(condition, new Set(["call"]), path);
+    assertOnlyKeys(condition.call, new Set(["name", "args"]), [
+      ...path,
+      "call",
+    ]);
+  } else {
+    throw new JemplParseError(
+      `Condition JSON call at '${formatConditionJsonPath(path)}' requires a function name`,
+    );
+  }
+
+  if (typeof name !== "string" || name.trim() === "") {
+    throw new JemplParseError(
+      `Condition JSON call at '${formatConditionJsonPath(path)}' requires a non-empty function name`,
+    );
+  }
+
+  if (!/^\w+$/.test(name)) {
+    throw new JemplParseError(
+      `Invalid condition JSON function name '${name}' at '${formatConditionJsonPath(path)}'`,
+    );
+  }
+
+  if (!Array.isArray(rawArgs)) {
+    throw new JemplParseError(
+      `Condition JSON call '${name}' at '${formatConditionJsonPath(path)}' requires args to be an array`,
+    );
+  }
+
+  return {
+    type: NodeType.FUNCTION,
+    name,
+    args: rawArgs.map((arg, index) =>
+      parseConditionJson(arg, functions, [...path, "args", index]),
+    ),
+  };
+};
+
+/**
+ * Parses a semantic JSON condition into the same condition AST used by string
+ * expressions. This keeps JSON conditions as an authoring layer instead of a
+ * separate runtime evaluator.
+ *
+ * @param {any} condition - Semantic condition JSON
+ * @param {Object} functions - Custom functions object
+ * @param {Array<string|number>} path - Error path
+ * @returns {Object} AST node representing the condition
+ */
+export const parseConditionJson = (
+  condition,
+  functions = {},
+  path = ["$when"],
+) => {
+  if (
+    typeof condition === "string" ||
+    typeof condition === "number" ||
+    typeof condition === "boolean" ||
+    condition === null
+  ) {
+    return {
+      type: NodeType.LITERAL,
+      value: condition,
+    };
+  }
+
+  if (Array.isArray(condition)) {
+    throw new JemplParseError(
+      `Condition JSON array at '${formatConditionJsonPath(path)}' must be wrapped in an operator or { literal: [...] }`,
+    );
+  }
+
+  if (!isPlainObject(condition)) {
+    throw new JemplParseError(
+      `Invalid condition JSON value at '${formatConditionJsonPath(path)}'`,
+    );
+  }
+
+  const keys = getOwnKeys(condition);
+  if (keys.length === 0) {
+    throw new JemplParseError(
+      `Condition JSON object at '${formatConditionJsonPath(path)}' must contain an operator`,
+    );
+  }
+
+  const operatorKeys = keys.filter((key) => JSON_CONDITION_OPERATORS.has(key));
+  if (operatorKeys.length === 0) {
+    throw new JemplParseError(
+      `Unknown condition JSON operator '${keys[0]}' at '${formatConditionJsonPath(path)}'`,
+    );
+  }
+
+  if (operatorKeys.length > 1) {
+    throw new JemplParseError(
+      `Condition JSON at '${formatConditionJsonPath(path)}' must contain exactly one operator`,
+    );
+  }
+
+  const operator = operatorKeys.includes("call") ? "call" : operatorKeys[0];
+
+  if (operator === "var") {
+    assertOnlyKeys(condition, new Set(["var"]), path);
+    if (typeof condition.var !== "string" || condition.var.trim() === "") {
+      throw new JemplParseError(
+        `Condition JSON var at '${formatConditionJsonPath(path)}' requires a non-empty path`,
+      );
+    }
+    return {
+      type: NodeType.VARIABLE,
+      path: condition.var,
+    };
+  }
+
+  if (operator === "literal") {
+    assertOnlyKeys(condition, new Set(["literal"]), path);
+    return {
+      type: NodeType.LITERAL,
+      value: condition.literal,
+    };
+  }
+
+  if (operator === "call") {
+    return parseConditionJsonFunction(condition, functions, path);
+  }
+
+  if (operator === "not") {
+    assertOnlyKeys(condition, new Set(["not"]), path);
+    return {
+      type: NodeType.UNARY,
+      op: UnaryOp.NOT,
+      operand: parseConditionJson(condition.not, functions, [...path, "not"]),
+    };
+  }
+
+  if (operator in JSON_LOGICAL_OPERATORS) {
+    assertOnlyKeys(condition, new Set([operator]), path);
+    return parseConditionJsonLogical(
+      condition[operator],
+      operator,
+      JSON_LOGICAL_OPERATORS[operator],
+      functions,
+      [...path, operator],
+    );
+  }
+
+  if (operator in JSON_BINARY_OPERATORS) {
+    assertOnlyKeys(condition, new Set([operator]), path);
+    const operands = parseConditionJsonOperandList(
+      condition[operator],
+      operator,
+      [...path, operator],
+    );
+    return {
+      type: NodeType.BINARY,
+      op: JSON_BINARY_OPERATORS[operator],
+      left: parseConditionJson(operands[0], functions, [...path, operator, 0]),
+      right: parseConditionJson(operands[1], functions, [...path, operator, 1]),
+    };
+  }
+
+  throw new JemplParseError(
+    `Unknown condition JSON operator '${operator}' at '${formatConditionJsonPath(path)}'`,
+  );
+};
+
+export const parseWhenCondition = (value, functions = {}) => {
+  if (value === undefined || value === null) {
+    throw new JemplParseError("Missing condition expression after '$when'");
+  }
+
+  if (typeof value === "string") {
+    if (value.trim() === "") {
+      throw new JemplParseError("Empty condition expression after '$when'");
+    }
+    return parseConditionExpression(value, functions);
+  }
+
+  if (isPlainObject(value)) {
+    return parseConditionJson(value, functions);
+  }
+
+  if (Array.isArray(value)) {
+    return parseConditionJson(value, functions);
+  }
+
+  return {
+    type: NodeType.LITERAL,
+    value,
   };
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "skipLibCheck": true,
+    "rootDir": "src",
     "outDir": "types",
     "moduleResolution": "NodeNext",
     "module": "NodeNext",


### PR DESCRIPTION
## Summary
- allow `$when` to accept semantic JSON conditions that compile into the existing condition AST
- expose `parseConditionJson` alongside the existing parse/render utilities
- document the JSON condition operators and bump the package version to 1.1.0

## Tests
- `bun run lint`
- `bun run types`
- `bun run test`