### PR TITLE
chore: enable trusted npm publishing

### DIFF
--- a/.github/workflows/release-package.yaml
+++ b/.github/workflows/release-package.yaml
@@ -5,6 +5,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  id-token: write # REQUIRED for OIDC
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -20,14 +24,12 @@ jobs:
       - name: Generate types
         run: bun run types
 
-      # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v3
+      # Setup npm registry for trusted publishing
+      - uses: actions/setup-node@v5
         with:
-          node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
 
       # Publish to npm
-      - name: Publish to npm
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+      - name: Publish to npm (Trusted)
+        run: npm publish --access public


### PR DESCRIPTION
## Summary
- add OIDC permissions for npm trusted publishing
- bump npm publishing workflow to Node 24 via actions/setup-node@v5
- remove the npm publish token and publish with trusted publishing

## Verification
- bunx prettier --check .github/workflows/release-package.yaml
- git diff --check