### PR TITLE
fix: align npm trusted publishing metadata

### DIFF
--- a/.github/workflows/release-package.yaml
+++ b/.github/workflows/release-package.yaml
@@ -25,11 +25,11 @@ jobs:
         run: bun run types
 
       # Setup npm registry for trusted publishing
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       # Publish to npm
       - name: Publish to npm (Trusted)
-        run: npm publish --access public
+        run: npm publish

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/yuusoft-org/jempl.git"
+    "url": "git+https://github.com/yuusoft-org/jempl.git"
   },
   "license": "MIT",
   "dependencies": {},


### PR DESCRIPTION
## Summary
- normalize package.json repository.url with npm's canonical git+https form
- bump actions/setup-node from v5 to v6 to avoid the deprecated always-auth npm config
- publish with plain npm publish since jempl is an unscoped public package

## Why
The failed release showed npm auto-correcting repository.url and warning about setup-node's always-auth config before returning E404. This removes the repo-side metadata/config warnings so trusted publishing gets the canonical package metadata.

If E404 persists after this, check the npm package trusted publisher settings for jempl: owner yuusoft-org, repo jempl, workflow filename release-package.yaml, with no environment unless the workflow adds one.

## Verification
- bunx prettier --check .github/workflows/release-package.yaml package.json
- npm --cache /tmp/npm-cache pack --dry-run
- git diff --check