### PR TITLE
Add public condition evaluator

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,31 @@ Each semantic JSON condition object must contain exactly one condition operator.
 Use `all` or `any` to combine multiple conditions. For function calls, `args` is
 metadata for `call`, not a separate condition operator.
 
+#### Evaluating Conditions Directly
+
+Use `evaluateCondition` when you need Jempl's condition semantics without
+rendering a template, such as selecting the first matching branch in an action
+runner.
+
+```javascript
+import { evaluateCondition } from "jempl";
+
+const matched = evaluateCondition(
+  {
+    gte: [
+      { var: "variables.trust" },
+      70
+    ]
+  },
+  {
+    variables: {
+      trust: 80
+    }
+  }
+);
+// true
+```
+
 #### Combining $when with $if
 
 You can use `$when` and `$if` together - `$when` is evaluated first:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jempl",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A JSON templating engine with conditionals, loops, and custom functions",
   "main": "src/index.js",
   "types": "types/index.d.ts",

--- a/src/evaluateCondition.js
+++ b/src/evaluateCondition.js
@@ -1,0 +1,68 @@
+import * as defaultFunctions from "./functions.js";
+import { evaluateConditionNode } from "./render.js";
+import { JemplParseError } from "./errors.js";
+import { parseConditionExpression, parseConditionJson } from "./parse/utils.js";
+
+const isParsedConditionNode = (value) =>
+  value !== null &&
+  typeof value === "object" &&
+  !Array.isArray(value) &&
+  typeof value.type === "number";
+
+const getFunctionsOption = (options = {}) => {
+  if (!options || typeof options !== "object") {
+    return {};
+  }
+
+  if (
+    Object.prototype.hasOwnProperty.call(options, "functions") ||
+    Object.prototype.hasOwnProperty.call(options, "partials")
+  ) {
+    return options.functions || {};
+  }
+
+  return options;
+};
+
+const parseConditionInput = (condition, functions) => {
+  if (isParsedConditionNode(condition)) {
+    return condition;
+  }
+
+  if (typeof condition === "string") {
+    if (condition.trim() === "") {
+      throw new JemplParseError("Empty condition expression");
+    }
+
+    return parseConditionExpression(condition, functions);
+  }
+
+  return parseConditionJson(condition, functions);
+};
+
+/**
+ * Evaluates a condition expression, semantic JSON condition, or parsed condition
+ * node with the same truthiness behavior used by $if and $when.
+ *
+ * @param {string|Object|boolean|number|null} condition - Condition to evaluate
+ * @param {Object} data - Data context used for variable lookup
+ * @param {Object} [options] - Options object or legacy functions object
+ * @param {Object.<string, Function>} [options.functions] - Custom functions
+ * @returns {boolean} Whether the condition is truthy
+ */
+const evaluateCondition = (condition, data = {}, options = {}) => {
+  const functions = getFunctionsOption(options);
+  const allFunctions = { ...defaultFunctions, ...functions };
+  const conditionNode = parseConditionInput(condition, allFunctions);
+
+  return Boolean(
+    evaluateConditionNode(
+      conditionNode,
+      { functions: allFunctions, partials: {} },
+      data,
+      {},
+    ),
+  );
+};
+
+export default evaluateCondition;

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,14 @@
 import render from "./render.js";
 import parse from "./parse/index.js";
 import parseAndRender from "./parseAndRender.js";
+import evaluateCondition from "./evaluateCondition.js";
 import { parseConditionExpression, parseConditionJson } from "./parse/utils.js";
 
 export {
   render,
   parseAndRender,
   parse,
+  evaluateCondition,
   parseConditionExpression,
   parseConditionJson,
 };

--- a/src/render.js
+++ b/src/render.js
@@ -1580,4 +1580,5 @@ const renderPathReference = (node, options, data, scope) => {
   return fullPath;
 };
 
+export { evaluateCondition as evaluateConditionNode };
 export default render;

--- a/test/evaluateCondition.test.js
+++ b/test/evaluateCondition.test.js
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import { evaluateCondition, parseConditionJson } from "../src/index.js";
+
+describe("evaluateCondition", () => {
+  it("evaluates semantic JSON conditions", () => {
+    const condition = {
+      all: [
+        {
+          gte: [{ var: "variables.trust" }, 70],
+        },
+        { var: "variables.metGuide" },
+      ],
+    };
+
+    expect(
+      evaluateCondition(condition, {
+        variables: {
+          trust: 80,
+          metGuide: true,
+        },
+      }),
+    ).toBe(true);
+
+    expect(
+      evaluateCondition(condition, {
+        variables: {
+          trust: 80,
+          metGuide: false,
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("treats missing variables as false", () => {
+    expect(evaluateCondition({ var: "missing" }, {})).toBe(false);
+  });
+
+  it("evaluates string condition expressions", () => {
+    expect(
+      evaluateCondition("variables.trust >= 70 && variables.metGuide", {
+        variables: {
+          trust: 75,
+          metGuide: true,
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("throws for empty string condition expressions", () => {
+    expect(() => evaluateCondition("   ", {})).toThrow(
+      "Parse Error: Empty condition expression",
+    );
+  });
+
+  it("evaluates parsed condition nodes", () => {
+    const conditionNode = parseConditionJson({
+      in: [{ var: "variables.role" }, { literal: ["admin", "owner"] }],
+    });
+
+    expect(
+      evaluateCondition(conditionNode, {
+        variables: {
+          role: "owner",
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("supports custom functions from options", () => {
+    const condition = {
+      gte: [
+        {
+          call: "scoreWithBonus",
+          args: [{ var: "score" }, { var: "bonus" }],
+        },
+        100,
+      ],
+    };
+
+    expect(
+      evaluateCondition(
+        condition,
+        {
+          score: 70,
+          bonus: 35,
+        },
+        {
+          functions: {
+            scoreWithBonus: (score, bonus) => score + bonus,
+          },
+        },
+      ),
+    ).toBe(true);
+  });
+
+  it("supports legacy functions object options", () => {
+    expect(
+      evaluateCondition(
+        {
+          call: "isReady",
+        },
+        {},
+        {
+          isReady: () => true,
+        },
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add public `evaluateCondition` helper for semantic JSON, string, and parsed condition nodes
- reuse the existing condition evaluator so direct checks match `$if` and `$when`
- document direct condition evaluation and bump package version to 1.1.1

## Tests
- `bunx vitest run test/evaluateCondition.test.js --reporter=verbose`
- `bun run lint`
- `bun run types`
- `bun run test`